### PR TITLE
feat: add semester strategy view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { EvaluationDialog } from './components/EvaluationDialog'
 import { SubjectView } from './components/SubjectView'
 import { ConfigDialog } from './components/ConfigDialog'
 import { Dashboard } from './components/Dashboard'
+import { SemesterView } from './components/SemesterView'
 import { ExportImportDialog } from './components/ExportImportDialog'
 import { WelcomeDialog } from './components/WelcomeDialog'
 import { Button } from './components/ui/button'
@@ -13,7 +14,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetDescri
 import { Card } from './components/ui/card'
 import { Separator } from './components/ui/separator'
 import { toast } from 'sonner'
-import { List, Plus, GearSix, Download, Upload, Trash, House, ArrowLeft, Question, Lightbulb, Star, GithubLogo, Info, Warning, Copy, FileText } from '@phosphor-icons/react'
+import { List, Plus, GearSix, Download, Upload, Trash, House, ArrowLeft, Question, Lightbulb, Star, GithubLogo, Info, Warning, Copy, FileText, ChartBar } from '@phosphor-icons/react'
 import { Popover, PopoverContent, PopoverTrigger } from './components/ui/popover'
 import { Alert, AlertDescription } from './components/ui/alert'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from './components/ui/dialog'
@@ -32,7 +33,7 @@ function App() {
   const [configDialogOpen, setConfigDialogOpen] = useState(false)
   const [sheetOpen, setSheetOpen] = useState(false)
   const [calculationMode, setCalculationMode] = useState<CalculationMode>('pessimistic')
-  const [view, setView] = useState<'dashboard' | 'subject'>('dashboard')
+  const [view, setView] = useState<'dashboard' | 'subject' | 'semester'>('dashboard')
   const [exportImportDialogOpen, setExportImportDialogOpen] = useState(false)
   const [exportImportMode, setExportImportMode] = useState<'export' | 'import'>('export')
   const [importData, setImportData] = useState<{ subjects: Subject[]; config?: Partial<Config>; exportDate?: string } | undefined>(undefined)
@@ -76,6 +77,11 @@ function App() {
   const handleBackToDashboard = () => {
     setSelectedSubjectId(null)
     setView('dashboard')
+  }
+
+  const handleOpenSemester = () => {
+    setView('semester')
+    setSheetOpen(false)
   }
 
   const handleSaveEvaluation = (evaluationData: Omit<Evaluation, 'id'>) => {
@@ -665,7 +671,7 @@ Total: 100% (20 pts.)
               </SheetContent>
             </Sheet>
 
-            {view === 'subject' && selectedSubject ? (
+            {view === 'subject' || view === 'semester' ? (
               <Button variant="ghost" size="icon" onClick={handleBackToDashboard} className="shrink-0">
                 <ArrowLeft size={20} className="text-primary" />
               </Button>
@@ -798,6 +804,13 @@ Total: 100% (20 pts.)
               </PopoverContent>
             </Popover>
 
+            {view !== 'semester' && (
+              <Button variant="outline" size="icon" onClick={handleOpenSemester} className="h-9 w-9 sm:h-10 sm:w-10" title="Vista semestral">
+                <ChartBar size={18} className="sm:hidden" />
+                <ChartBar size={20} className="hidden sm:block" />
+              </Button>
+            )}
+
             <Button variant="outline" size="icon" onClick={() => setConfigDialogOpen(true)} className="h-9 w-9 sm:h-10 sm:w-10">
               <GearSix size={18} className="sm:hidden" />
               <GearSix size={20} className="hidden sm:block" />
@@ -813,6 +826,14 @@ Total: 100% (20 pts.)
             config={configData}
             onSelectSubject={handleSelectSubject}
             onAddSubject={() => setSubjectDialogOpen(true)}
+          />
+        ) : view === 'semester' ? (
+          <SemesterView
+            subjects={subjectsData}
+            config={configData}
+            calculationMode={calculationMode}
+            onSelectSubject={handleSelectSubject}
+            onBack={handleBackToDashboard}
           />
         ) : selectedSubject && calculation && configData ? (
           <SubjectView

--- a/src/components/SemesterSummary.tsx
+++ b/src/components/SemesterSummary.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, ReferenceLine, Cell, Tooltip } from 'recharts'
+import { CheckCircle, WarningCircle, X, Student } from '@phosphor-icons/react'
+import { SemesterSummary as SemesterSummaryType, Config } from '../types'
+import { Card } from './ui/card'
+import { calculateRequiredNotes } from '../lib/calculations'
+
+interface SemesterSummaryProps {
+  summary: SemesterSummaryType
+  config: Config
+}
+
+const CATEGORY_COLORS = {
+  approved:   'var(--accent)',
+  safe:       'var(--primary)',
+  atRisk:     'var(--orange)',
+  impossible: 'var(--destructive)',
+  notStarted: 'var(--muted-foreground)',
+} as const
+
+type Category = keyof typeof CATEGORY_COLORS
+
+const statCards = [
+  {
+    key: 'approved' as Category,
+    label: 'Aprobadas',
+    icon: CheckCircle,
+    colorClass: 'text-accent',
+    bgClass: 'bg-accent/10',
+  },
+  {
+    key: 'safe' as Category,
+    label: 'En buen camino',
+    icon: WarningCircle,
+    colorClass: 'text-primary',
+    bgClass: 'bg-primary/10',
+  },
+  {
+    key: 'atRisk' as Category,
+    label: 'En riesgo',
+    icon: WarningCircle,
+    colorClass: 'text-orange',
+    bgClass: 'bg-orange/10',
+  },
+  {
+    key: 'impossible' as Category,
+    label: 'Imposible',
+    icon: X,
+    colorClass: 'text-destructive',
+    bgClass: 'bg-destructive/10',
+  },
+]
+
+export function SemesterSummary({ summary, config }: SemesterSummaryProps) {
+  const allSubjects = useMemo(() => [
+    ...summary.impossible,
+    ...summary.atRisk,
+    ...summary.notStarted,
+    ...summary.safe,
+    ...summary.approved,
+  ], [summary])
+
+  const chartData = useMemo(() => {
+    const categoryOf = (id: string): Category => {
+      if (summary.approved.some(s => s.id === id))  return 'approved'
+      if (summary.impossible.some(s => s.id === id)) return 'impossible'
+      if (summary.safe.some(s => s.id === id))      return 'safe'
+      if (summary.atRisk.some(s => s.id === id))    return 'atRisk'
+      return 'notStarted'
+    }
+
+    return allSubjects
+      .map(subject => {
+        const result = calculateRequiredNotes(subject, config)
+        const truncated = subject.name.length > 22
+          ? subject.name.slice(0, 20) + '…'
+          : subject.name
+        return {
+          id: subject.id,
+          name: truncated,
+          current: Math.round(result.currentPercentage * 10) / 10,
+          category: categoryOf(subject.id),
+        }
+      })
+      .sort((a, b) => a.current - b.current)
+  }, [allSubjects, config, summary])
+
+  const total = allSubjects.length + summary.notStarted.length
+
+  if (total === 0) {
+    return (
+      <Card className="p-6 flex flex-col items-center gap-3 text-center text-muted-foreground">
+        <Student size={40} className="opacity-40" />
+        <p className="text-sm">Aún no tienes materias. Agrégalas desde el inicio.</p>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {statCards.map(({ key, label, icon: Icon, colorClass, bgClass }) => (
+          <Card key={key} className="p-4 flex flex-col gap-2">
+            <div className={`w-8 h-8 rounded-full ${bgClass} flex items-center justify-center`}>
+              <Icon size={16} className={colorClass} weight="fill" />
+            </div>
+            <div>
+              <p className={`text-2xl font-bold font-data ${colorClass}`}>
+                {summary[key].length}
+              </p>
+              <p className="text-xs text-muted-foreground">{label}</p>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      {chartData.length > 0 && (
+        <Card className="p-4">
+          <p className="text-sm font-semibold mb-3">Progreso por materia</p>
+          <ResponsiveContainer width="100%" height={Math.max(120, chartData.length * 36)}>
+            <BarChart
+              layout="vertical"
+              data={chartData}
+              margin={{ top: 0, right: 40, left: 0, bottom: 0 }}
+            >
+              <XAxis
+                type="number"
+                domain={[0, 100]}
+                tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={v => `${v}%`}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={110}
+                tick={{ fill: 'hsl(var(--foreground))', fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                formatter={(value) => [`${value}%`, 'Progreso actual']}
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '6px',
+                  fontSize: 12,
+                }}
+              />
+              <ReferenceLine
+                x={config.passingPercentage}
+                stroke="hsl(var(--primary))"
+                strokeDasharray="4 3"
+                strokeWidth={1.5}
+                label={{
+                  value: `${config.passingPercentage}%`,
+                  position: 'right',
+                  fill: 'hsl(var(--primary))',
+                  fontSize: 10,
+                  fontWeight: 600,
+                }}
+              />
+              <Bar dataKey="current" radius={[0, 3, 3, 0]} maxBarSize={22}>
+                {chartData.map(entry => (
+                  <Cell key={entry.id} fill={CATEGORY_COLORS[entry.category]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/components/SemesterView.tsx
+++ b/src/components/SemesterView.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react'
+import { ArrowLeft } from '@phosphor-icons/react'
+import { Subject, Config, CalculationMode } from '../types'
+import { Button } from './ui/button'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './ui/tabs'
+import { SemesterSummary } from './SemesterSummary'
+import { UrgencyRanking } from './UrgencyRanking'
+import { UpcomingEvaluations } from './UpcomingEvaluations'
+import { getSemesterSummary } from '../lib/calculations'
+
+interface SemesterViewProps {
+  subjects: Subject[]
+  config: Config
+  calculationMode: CalculationMode
+  onSelectSubject: (id: string) => void
+  onBack: () => void
+}
+
+export function SemesterView({ subjects, config, calculationMode, onSelectSubject, onBack }: SemesterViewProps) {
+  const summary = useMemo(
+    () => getSemesterSummary(subjects, config),
+    [subjects, config]
+  )
+
+  return (
+    <div className="flex flex-col gap-4 sm:gap-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={onBack} className="shrink-0">
+          <ArrowLeft size={18} className="text-primary" />
+        </Button>
+        <div>
+          <h2 className="text-lg sm:text-xl font-bold">Vista Semestral</h2>
+          <p className="text-xs text-muted-foreground">
+            {subjects.length} materia{subjects.length !== 1 ? 's' : ''} •{' '}
+            {summary.approved.length} aprobada{summary.approved.length !== 1 ? 's' : ''} •{' '}
+            {summary.atRisk.length + summary.impossible.length} en riesgo
+          </p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="resumen">
+        <TabsList className="w-full sm:w-auto">
+          <TabsTrigger value="resumen" className="flex-1 sm:flex-none">Resumen</TabsTrigger>
+          <TabsTrigger value="proximas" className="flex-1 sm:flex-none">Próximas evaluaciones</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="resumen" className="mt-4 flex flex-col gap-4">
+          <SemesterSummary summary={summary} config={config} />
+          <UrgencyRanking subjects={subjects} config={config} onSelectSubject={onSelectSubject} />
+        </TabsContent>
+
+        <TabsContent value="proximas" className="mt-4">
+          <UpcomingEvaluations
+            subjects={subjects}
+            config={config}
+            calculationMode={calculationMode}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/src/components/UpcomingEvaluations.tsx
+++ b/src/components/UpcomingEvaluations.tsx
@@ -1,0 +1,210 @@
+import { useState, useMemo } from 'react'
+import { CalendarBlank, ClockCountdown, CheckCircle } from '@phosphor-icons/react'
+import { format } from 'date-fns'
+import { es } from 'date-fns/locale'
+import { Subject, Config, CalculationMode } from '../types'
+import { Card } from './ui/card'
+import { Badge } from './ui/badge'
+import { Input } from './ui/input'
+import { getUpcomingEvaluations, calculateRequiredNotes } from '../lib/calculations'
+
+interface UpcomingEvaluationsProps {
+  subjects: Subject[]
+  config: Config
+  calculationMode: CalculationMode
+}
+
+const RANGE_OPTIONS: { label: string; days: number }[] = [
+  { label: '7 días', days: 7 },
+  { label: '14 días', days: 14 },
+  { label: '30 días', days: 30 },
+]
+
+export function UpcomingEvaluations({ subjects, config, calculationMode }: UpcomingEvaluationsProps) {
+  const [daysAhead, setDaysAhead] = useState(14)
+  const [simulated, setSimulated] = useState<Map<string, number>>(new Map())
+
+  const upcoming = useMemo(
+    () => getUpcomingEvaluations(subjects, config, daysAhead),
+    [subjects, config, daysAhead]
+  )
+
+  const simulatedResults = useMemo(() => {
+    const results = new Map<string, { isApproved: boolean; currentPercentage: number } | null>()
+    for (const [evalId, points] of simulated.entries()) {
+      const item = upcoming.find(u => u.evaluation.id === evalId)
+      if (!item) continue
+
+      const modifiedSubject: Subject = {
+        ...item.subject,
+        evaluations: item.subject.evaluations.map(e => {
+          if (e.id === evalId) return { ...e, obtainedPoints: points }
+          if (e.isSummative && e.subEvaluations) {
+            return {
+              ...e,
+              subEvaluations: e.subEvaluations.map(sub =>
+                sub.id === evalId ? { ...sub, obtainedPoints: points } : sub
+              ),
+            }
+          }
+          return e
+        }),
+      }
+      const result = calculateRequiredNotes(modifiedSubject, config)
+      results.set(evalId, { isApproved: result.isApproved, currentPercentage: result.currentPercentage })
+    }
+    return results
+  }, [simulated, upcoming, config])
+
+  const setSimulatedValue = (evalId: string, value: string) => {
+    const num = parseFloat(value)
+    setSimulated(prev => {
+      const next = new Map(prev)
+      if (value === '' || isNaN(num)) {
+        next.delete(evalId)
+      } else {
+        next.set(evalId, num)
+      }
+      return next
+    })
+  }
+
+  if (upcoming.length === 0) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-2">
+          {RANGE_OPTIONS.map(opt => (
+            <button
+              key={opt.days}
+              onClick={() => setDaysAhead(opt.days)}
+              className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+                daysAhead === opt.days
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-card text-muted-foreground border-border hover:text-foreground'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        <Card className="p-8 flex flex-col items-center gap-3 text-center text-muted-foreground">
+          <CalendarBlank size={40} className="opacity-40" />
+          <div>
+            <p className="text-sm font-medium">Sin evaluaciones próximas</p>
+            <p className="text-xs mt-1">
+              No hay evaluaciones pendientes con fecha en los próximos {daysAhead} días.
+              Agrega fechas a tus evaluaciones para verlas aquí.
+            </p>
+          </div>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        {RANGE_OPTIONS.map(opt => (
+          <button
+            key={opt.days}
+            onClick={() => setDaysAhead(opt.days)}
+            className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+              daysAhead === opt.days
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-card text-muted-foreground border-border hover:text-foreground'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+        <span className="text-xs text-muted-foreground ml-auto">
+          {upcoming.length} evaluación{upcoming.length !== 1 ? 'es' : ''}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {upcoming.map(item => {
+          const { subject, evaluation, daysUntil, requiredPoints } = item
+          const simResult = simulatedResults.get(evaluation.id)
+          const simValue = simulated.get(evaluation.id)
+
+          const urgencyColor = item.urgencyScore >= 70
+            ? 'text-destructive'
+            : item.urgencyScore >= 40
+            ? 'text-orange'
+            : 'text-muted-foreground'
+
+          return (
+            <Card key={`${subject.id}-${evaluation.id}`} className="p-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+                <div className="flex items-start gap-3 flex-1 min-w-0">
+                  <div className={`flex flex-col items-center gap-0.5 shrink-0 pt-0.5 ${urgencyColor}`}>
+                    <ClockCountdown size={18} weight="fill" />
+                    <span className="text-xs font-data font-bold">
+                      {daysUntil === 0 ? 'Hoy' : `${daysUntil}d`}
+                    </span>
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-muted-foreground">{subject.name}</p>
+                    <p className="text-sm font-medium truncate">{evaluation.name}</p>
+                    <div className="flex items-center gap-2 mt-1 flex-wrap">
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <CalendarBlank size={11} />
+                        <span>
+                          {evaluation.date
+                            ? format(new Date(evaluation.date), 'dd MMM yyyy', { locale: es })
+                            : ''}
+                        </span>
+                      </div>
+                      <Badge variant="outline" className="text-xs px-1.5 py-0">
+                        {evaluation.weight}%
+                      </Badge>
+                      {evaluation.section && (
+                        <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                          {evaluation.section === 'theory' ? 'Teoría' : 'Práctica'}
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-2 sm:items-end shrink-0">
+                  <div className="text-right">
+                    <p className="text-xs text-muted-foreground">Necesitas (pesimista)</p>
+                    <p className="text-sm font-data font-bold text-primary">
+                      {requiredPoints} / {evaluation.maxPoints} pts
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <p className="text-xs text-muted-foreground">¿Y si obtienes…?</p>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={evaluation.maxPoints}
+                        step={0.5}
+                        placeholder={`0–${evaluation.maxPoints}`}
+                        value={simValue ?? ''}
+                        onChange={e => setSimulatedValue(evaluation.id, e.target.value)}
+                        className="w-24 h-8 text-xs font-data text-right"
+                      />
+                      {simResult && (
+                        <div className={`flex items-center gap-1 text-xs font-medium ${simResult.isApproved ? 'text-accent' : 'text-orange'}`}>
+                          {simResult.isApproved && <CheckCircle size={14} weight="fill" />}
+                          <span>{simResult.isApproved ? 'Aprobado' : `${simResult.currentPercentage.toFixed(1)}%`}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/UrgencyRanking.tsx
+++ b/src/components/UrgencyRanking.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react'
+import { ArrowRight, SortDescending } from '@phosphor-icons/react'
+import { Subject, Config } from '../types'
+import { Card } from './ui/card'
+import { Badge } from './ui/badge'
+import { Button } from './ui/button'
+import { StatusIndicator } from './StatusIndicator'
+import { getSemesterSummary, getSubjectUrgencyScore, calculateRequiredNotes, getProgressStatus, calculateProgressMetrics } from '../lib/calculations'
+
+interface UrgencyRankingProps {
+  subjects: Subject[]
+  config: Config
+  onSelectSubject: (id: string) => void
+}
+
+function urgencyLabel(score: number): { label: string; variant: 'destructive' | 'default' | 'secondary' | 'outline' } {
+  if (score >= 70) return { label: 'Alta', variant: 'destructive' }
+  if (score >= 40) return { label: 'Media', variant: 'default' }
+  return { label: 'Baja', variant: 'secondary' }
+}
+
+export function UrgencyRanking({ subjects, config }: UrgencyRankingProps & { onSelectSubject: (id: string) => void }) {
+  const ranked = useMemo(() => {
+    const summary = getSemesterSummary(subjects, config)
+    const approvedIds = new Set(summary.approved.map(s => s.id))
+    const notStartedIds = new Set(summary.notStarted.map(s => s.id))
+
+    return [...subjects]
+      .map(subject => {
+        const score = getSubjectUrgencyScore(subject, config)
+        const result = calculateRequiredNotes(subject, config)
+        const evaluatedWeight = subject.evaluations
+          .filter(e => e.obtainedPoints !== undefined || (e.isSummative && e.subEvaluations?.every(s => s.obtainedPoints !== undefined)))
+          .reduce((sum, e) => sum + e.weight, 0)
+        const statusInfo = getProgressStatus({
+          current: result.currentPercentage,
+          evaluated: evaluatedWeight,
+          passingPoint: config.passingPercentage,
+          target: 100,
+        })
+        return { subject, score, statusInfo, isApproved: approvedIds.has(subject.id), notStarted: notStartedIds.has(subject.id) }
+      })
+      .sort((a, b) => {
+        if (a.isApproved !== b.isApproved) return a.isApproved ? 1 : -1
+        if (a.notStarted !== b.notStarted) return a.notStarted ? 1 : -1
+        return b.score - a.score
+      })
+  }, [subjects, config])
+
+  if (subjects.length === 0) return null
+
+  return (
+    <Card className="p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <SortDescending size={16} className="text-primary" />
+        <h3 className="text-sm font-semibold">Ranking de urgencia</h3>
+        <span className="text-xs text-muted-foreground ml-auto">¿Qué estudiar primero?</span>
+      </div>
+
+      <div className="flex flex-col divide-y">
+        {ranked.map(({ subject, score, statusInfo, isApproved, notStarted }, index) => {
+          const { label: urgLabel, variant } = urgencyLabel(score)
+          return (
+            <div key={subject.id} className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
+              <span className="text-sm font-data font-bold text-muted-foreground w-5 shrink-0 text-center">
+                {index + 1}
+              </span>
+
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{subject.name}</p>
+              </div>
+
+              <div className="flex items-center gap-2 shrink-0">
+                {!isApproved && !notStarted && (
+                  <Badge variant={variant} className="text-xs px-1.5 py-0">
+                    {urgLabel}
+                  </Badge>
+                )}
+                <StatusIndicator statusInfo={statusInfo} size="sm" showTooltip />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Card>
+  )
+}

--- a/src/lib/calculations.test.ts
+++ b/src/lib/calculations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   applyRounding,
   percentageToPoints,
@@ -8,6 +8,9 @@ import {
   calculateCurrentPercentage,
   calculateRequiredNotes,
   validateWeights,
+  getSemesterSummary,
+  getUpcomingEvaluations,
+  getSubjectUrgencyScore,
 } from './calculations'
 import type { Evaluation, Subject, Config } from '../types'
 
@@ -403,6 +406,188 @@ describe('calculateRequiredNotes', () => {
       const result = calculateRequiredNotes(makeSubject(evals), defaultConfig)
       expect(result.requiredNotes).toHaveLength(1)
       expect(result.requiredNotes[0].evaluationId).toBe('s2')
+    })
+  })
+})
+
+// ── Semester strategy calculations ────────────────────────────────────────
+
+// Pin "today" so date-based tests are deterministic
+const FIXED_TODAY = new Date('2026-06-16T00:00:00.000Z')
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function withFixedDate(fn: () => void) {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_TODAY)
+  fn()
+  vi.useRealTimers()
+}
+
+function dateFromToday(offsetDays: number): string {
+  const d = new Date(FIXED_TODAY)
+  d.setDate(d.getDate() + offsetDays)
+  return d.toISOString().split('T')[0]
+}
+
+describe('getSemesterSummary', () => {
+  it('places approved subject in approved list', () => {
+    const evals = [makeEval({ id: 'e1', weight: 100, maxPoints: 20, obtainedPoints: 20 })]
+    const summary = getSemesterSummary([makeSubject(evals)], defaultConfig)
+    expect(summary.approved).toHaveLength(1)
+    expect(summary.safe).toHaveLength(0)
+    expect(summary.atRisk).toHaveLength(0)
+  })
+
+  it('places subject with no completed evaluations in notStarted', () => {
+    const evals = [makeEval({ id: 'e1', weight: 100 })]
+    const summary = getSemesterSummary([makeSubject(evals)], defaultConfig)
+    expect(summary.notStarted).toHaveLength(1)
+  })
+
+  it('places subject with high performance in safe', () => {
+    // 14/20 * 50 = 35% from e1, 50% pending → 70% of 50 evaluated → high_performance
+    const evals = [
+      makeEval({ id: 'e1', weight: 50, maxPoints: 20, obtainedPoints: 14 }),
+      makeEval({ id: 'e2', weight: 50, maxPoints: 20 }),
+    ]
+    const summary = getSemesterSummary([makeSubject(evals)], defaultConfig)
+    expect(summary.safe).toHaveLength(1)
+  })
+
+  it('places subject with low performance in atRisk', () => {
+    // 5/20 * 50 = 12.5% from e1 → 25% of 50 evaluated → low_performance
+    const evals = [
+      makeEval({ id: 'e1', weight: 50, maxPoints: 20, obtainedPoints: 5 }),
+      makeEval({ id: 'e2', weight: 50, maxPoints: 20 }),
+    ]
+    const summary = getSemesterSummary([makeSubject(evals)], defaultConfig)
+    expect(summary.atRisk).toHaveLength(1)
+  })
+
+  it('places subject where passing is impossible in impossible', () => {
+    // 2/20 * 80 = 8%, remaining 20% → max possible = 28% < 60%
+    const evals = [
+      makeEval({ id: 'e1', weight: 80, maxPoints: 20, obtainedPoints: 2 }),
+      makeEval({ id: 'e2', weight: 20, maxPoints: 20 }),
+    ]
+    const summary = getSemesterSummary([makeSubject(evals)], defaultConfig)
+    expect(summary.impossible).toHaveLength(1)
+  })
+
+  it('handles multiple subjects across different categories', () => {
+    const approved = makeSubject(
+      [makeEval({ id: 'e1', weight: 100, maxPoints: 20, obtainedPoints: 20 })],
+      { id: 'approved' }
+    )
+    const notStarted = makeSubject(
+      [makeEval({ id: 'e2', weight: 100 })],
+      { id: 'notStarted' }
+    )
+    const summary = getSemesterSummary([approved, notStarted], defaultConfig)
+    expect(summary.approved).toHaveLength(1)
+    expect(summary.notStarted).toHaveLength(1)
+  })
+})
+
+describe('getUpcomingEvaluations', () => {
+  it('returns empty array when no evaluations have dates', () => {
+    withFixedDate(() => {
+      const evals = [makeEval({ id: 'e1', weight: 100 })]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  it('excludes evaluations that already have a grade', () => {
+    withFixedDate(() => {
+      const evals = [
+        makeEval({ id: 'e1', weight: 100, obtainedPoints: 15, date: dateFromToday(3) }),
+      ]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  it('excludes evaluations outside the daysAhead window', () => {
+    withFixedDate(() => {
+      const evals = [
+        makeEval({ id: 'e1', weight: 100, date: dateFromToday(20) }),
+      ]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig, 14)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  it('excludes evaluations in the past', () => {
+    withFixedDate(() => {
+      const evals = [
+        makeEval({ id: 'e1', weight: 100, date: dateFromToday(-1) }),
+      ]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  it('returns upcoming pending evaluations sorted by date', () => {
+    withFixedDate(() => {
+      const evals = [
+        makeEval({ id: 'e1', weight: 50, date: dateFromToday(7) }),
+        makeEval({ id: 'e2', weight: 50, date: dateFromToday(3) }),
+      ]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(result).toHaveLength(2)
+      expect(result[0].evaluation.id).toBe('e2') // closer first
+      expect(result[1].evaluation.id).toBe('e1')
+    })
+  })
+
+  it('urgencyScore is higher for evaluations that are sooner', () => {
+    withFixedDate(() => {
+      const evals = [
+        makeEval({ id: 'e1', weight: 50, date: dateFromToday(1) }),
+        makeEval({ id: 'e2', weight: 50, date: dateFromToday(13) }),
+      ]
+      const result = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(result[0].urgencyScore).toBeGreaterThan(result[1].urgencyScore)
+    })
+  })
+
+  it('urgencyScore is between 0 and 100', () => {
+    withFixedDate(() => {
+      const evals = [makeEval({ id: 'e1', weight: 100, date: dateFromToday(5) })]
+      const [item] = getUpcomingEvaluations([makeSubject(evals)], defaultConfig)
+      expect(item.urgencyScore).toBeGreaterThanOrEqual(0)
+      expect(item.urgencyScore).toBeLessThanOrEqual(100)
+    })
+  })
+})
+
+describe('getSubjectUrgencyScore', () => {
+  it('returns 0 when subject has no evaluations with dates', () => {
+    withFixedDate(() => {
+      const subject = makeSubject([makeEval({ id: 'e1', weight: 100 })])
+      expect(getSubjectUrgencyScore(subject, defaultConfig)).toBe(0)
+    })
+  })
+
+  it('returns 0 when all evaluations are completed', () => {
+    withFixedDate(() => {
+      const subject = makeSubject([
+        makeEval({ id: 'e1', weight: 100, obtainedPoints: 15, date: dateFromToday(3) }),
+      ])
+      expect(getSubjectUrgencyScore(subject, defaultConfig)).toBe(0)
+    })
+  })
+
+  it('returns a positive score for a pending evaluation with an upcoming date', () => {
+    withFixedDate(() => {
+      const subject = makeSubject([
+        makeEval({ id: 'e1', weight: 100, date: dateFromToday(5) }),
+      ])
+      expect(getSubjectUrgencyScore(subject, defaultConfig)).toBeGreaterThan(0)
     })
   })
 })

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -1,4 +1,5 @@
-import { Subject, Evaluation, Config, CalculationResult, ProgressParams, StatusInfo, ProgressStatus, RoundingType } from '../types'
+import { differenceInDays } from 'date-fns'
+import { Subject, Evaluation, Config, CalculationResult, ProgressParams, StatusInfo, ProgressStatus, RoundingType, SemesterSummary, UpcomingEvaluation } from '../types'
 
 /**
  * Aplica el tipo de redondeo configurado a un valor numérico.
@@ -470,4 +471,136 @@ export function validateWeights(subject: Subject): { isValid: boolean; message?:
   }
   
   return { isValid: true }
+}
+
+// ── Semester strategy calculations ────────────────────────────────────────
+
+const STATUS_PRIORITY: Record<ProgressStatus, number> = {
+  impossible: 0,
+  low_performance: 1,
+  medium_performance: 2,
+  high_performance: 3,
+  approved: 4,
+  no_evaluations: 5,
+}
+
+function worstStatus(a: ProgressStatus, b: ProgressStatus): ProgressStatus {
+  return STATUS_PRIORITY[a] <= STATUS_PRIORITY[b] ? a : b
+}
+
+export function getSemesterSummary(subjects: Subject[], config: Config): SemesterSummary {
+  const summary: SemesterSummary = { approved: [], safe: [], atRisk: [], impossible: [], notStarted: [] }
+
+  for (const subject of subjects) {
+    const result = calculateRequiredNotes(subject, config)
+
+    if (result.isApproved) {
+      summary.approved.push(subject)
+      continue
+    }
+
+    let status: ProgressStatus
+
+    if (subject.hasSplit && subject.theoryWeight && subject.practiceWeight) {
+      const theoryEvals = subject.evaluations.filter(e => e.section === 'theory')
+      const practiceEvals = subject.evaluations.filter(e => e.section === 'practice')
+
+      const theoryEvaluated = theoryEvals.filter(isEvaluationFullyComplete).reduce((s, e) => s + e.weight, 0)
+      const practiceEvaluated = practiceEvals.filter(isEvaluationFullyComplete).reduce((s, e) => s + e.weight, 0)
+
+      const theoryPassingPoint = (subject.theoryWeight * config.passingPercentage) / 100
+      const practicePassingPoint = (subject.practiceWeight * config.passingPercentage) / 100
+
+      const theoryStatus = getProgressStatus({
+        current: result.currentTheoryPercentage ?? 0,
+        evaluated: theoryEvaluated,
+        passingPoint: theoryPassingPoint,
+        target: subject.theoryWeight,
+        label: 'teoría',
+      })
+      const practiceStatus = getProgressStatus({
+        current: result.currentPracticePercentage ?? 0,
+        evaluated: practiceEvaluated,
+        passingPoint: practicePassingPoint,
+        target: subject.practiceWeight,
+        label: 'práctica',
+      })
+
+      status = worstStatus(theoryStatus.status, practiceStatus.status)
+    } else {
+      const evaluatedWeight = subject.evaluations
+        .filter(isEvaluationFullyComplete)
+        .reduce((s, e) => s + e.weight, 0)
+
+      status = getProgressStatus({
+        current: result.currentPercentage,
+        evaluated: evaluatedWeight,
+        passingPoint: config.passingPercentage,
+        target: 100,
+      }).status
+    }
+
+    switch (status) {
+      case 'no_evaluations': summary.notStarted.push(subject); break
+      case 'impossible':     summary.impossible.push(subject); break
+      case 'high_performance': summary.safe.push(subject);    break
+      default:               summary.atRisk.push(subject);    break
+    }
+  }
+
+  return summary
+}
+
+export function getUpcomingEvaluations(
+  subjects: Subject[],
+  config: Config,
+  daysAhead: number = 14
+): UpcomingEvaluation[] {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const results: UpcomingEvaluation[] = []
+
+  for (const subject of subjects) {
+    const calcResult = calculateRequiredNotes(subject, config)
+    const requiredMap = new Map(calcResult.requiredNotes.map(n => [n.evaluationId, n.pessimistic]))
+
+    for (const eval_ of subject.evaluations) {
+      if (eval_.isSummative && eval_.subEvaluations?.length) {
+        if (!eval_.date) continue
+        const evalDate = new Date(eval_.date)
+        evalDate.setHours(0, 0, 0, 0)
+        const daysUntil = differenceInDays(evalDate, today)
+        if (daysUntil < 0 || daysUntil > daysAhead) continue
+
+        for (const sub of eval_.subEvaluations) {
+          if (sub.obtainedPoints !== undefined) continue
+          const requiredPoints = requiredMap.get(sub.id) ?? 0
+          const daysFactor = 1 - daysUntil / daysAhead
+          const noteFactor = sub.maxPoints > 0 ? requiredPoints / sub.maxPoints : 0
+          const urgencyScore = Math.round((daysFactor * 0.6 + noteFactor * 0.4) * 100)
+          results.push({ subject, evaluation: { ...sub, date: eval_.date }, daysUntil, requiredPoints, urgencyScore })
+        }
+      } else {
+        if (!eval_.date || eval_.obtainedPoints !== undefined) continue
+        const evalDate = new Date(eval_.date)
+        evalDate.setHours(0, 0, 0, 0)
+        const daysUntil = differenceInDays(evalDate, today)
+        if (daysUntil < 0 || daysUntil > daysAhead) continue
+
+        const requiredPoints = requiredMap.get(eval_.id) ?? 0
+        const daysFactor = 1 - daysUntil / daysAhead
+        const noteFactor = eval_.maxPoints > 0 ? requiredPoints / eval_.maxPoints : 0
+        const urgencyScore = Math.round((daysFactor * 0.6 + noteFactor * 0.4) * 100)
+        results.push({ subject, evaluation: eval_, daysUntil, requiredPoints, urgencyScore })
+      }
+    }
+  }
+
+  return results.sort((a, b) => a.daysUntil - b.daysUntil)
+}
+
+export function getSubjectUrgencyScore(subject: Subject, config: Config): number {
+  const upcoming = getUpcomingEvaluations([subject], config, 30)
+  if (upcoming.length === 0) return 0
+  return Math.max(...upcoming.map(u => u.urgencyScore))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,3 +87,19 @@ export interface ProgressParams {
   target: number            // Peso total objetivo (usualmente 100)
   label?: string            // Etiqueta opcional para mensajes
 }
+
+export interface UpcomingEvaluation {
+  subject: Subject
+  evaluation: Evaluation
+  daysUntil: number
+  requiredPoints: number    // en puntos (modo pesimista)
+  urgencyScore: number      // 0–100
+}
+
+export interface SemesterSummary {
+  approved: Subject[]
+  safe: Subject[]           // en progreso, rendimiento >= 60%
+  atRisk: Subject[]         // en progreso, rendimiento < 60%
+  impossible: Subject[]
+  notStarted: Subject[]     // sin evaluaciones completadas
+}


### PR DESCRIPTION
## Summary

Add a new **Semester Strategy View** that gives students a cross-subject perspective of their entire semester at a glance. This transforms GapTo10 from a reactive calculator into a proactive planning assistant.

Three new interactive components:

1. **SemesterSummary** — 4 stat cards (Aprobadas/En buen camino/En riesgo/Imposible) + horizontal bar chart showing all subjects' progress vs passing threshold
2. **UrgencyRanking** — Subjects ranked by urgency score (proximity of next evaluation × required grade) so students know what to prioritize
3. **UpcomingEvaluations** — Radar of evaluations in the next 7/14/30 days with required notes + inline "what-if" simulator that recomputes subject status in real-time

## What Changed

**Core calculations** (`src/lib/calculations.ts`):
- `getSemesterSummary(subjects, config)` — classifies all subjects into approved/safe/atRisk/impossible/notStarted
- `getUpcomingEvaluations(subjects, config, daysAhead)` — returns pending evaluations within N days with urgency scores
- `getSubjectUrgencyScore(subject, config)` — single-number urgency metric per subject

**Types** (`src/types.ts`):
- `SemesterSummary` interface
- `UpcomingEvaluation` interface

**UI Components**:
- `SemesterSummary.tsx` — stat cards + Recharts BarChart
- `UrgencyRanking.tsx` — ranked subject list with status indicators
- `UpcomingEvaluations.tsx` — evaluation radar with interactive simulation inputs
- `SemesterView.tsx` — wrapper with tabs (Resumen / Próximas evaluaciones)

**Integration** (`src/App.tsx`):
- Extended view state to include `'semester'` mode
- Added ChartBar button in header (only visible when not already in semester view)
- Wired SemesterView into the main render conditional

**Tests** (`src/lib/calculations.test.ts`):
- 16 new tests for the three new calculation functions
- All 53 tests pass (37 existing + 16 new)

## Why

Students need to see the big picture: *"What should I study this week?"* The previous design answered *"What do I need in this class?"* but not the meta-question of resource allocation across multiple classes.

This view uses existing data (subjects, evaluations with dates, calculated required notes) to generate a priority order without any backend changes or new data collection.

## Test Plan

- ✅ `pnpm test` — 53/53 pass
- ✅ `pnpm build` — compiles without errors
- ✅ UI: ChartBar button appears in header on Dashboard and SubjectView
- ✅ UI: Clicking ChartBar opens SemesterView with two tabs
- ✅ Resumen tab: Stat cards show correct counts; BarChart renders correctly
- ✅ Resumen tab: UrgencyRanking sorts by urgency score (nearest+highest-effort = top)
- ✅ Próximas evaluaciones tab: Shows only evaluations with dates in the selected range (7/14/30 days)
- ✅ Próximas evaluaciones tab: What-if simulator updates subject status live as user enters hypothetical grades
- ✅ Navigation: Back button returns to Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)