### PR TITLE
fix: use pnpm 10.x for Node.js v20 compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm 11.x requires Node.js 22+. GitHub Actions uses Node 20, so downgrade to pnpm 10.x which is compatible.