### PR TITLE
fix: resolve SelectItem empty value error in difficulty selects

### DIFF
--- a/src/components/EvaluationDialog.tsx
+++ b/src/components/EvaluationDialog.tsx
@@ -260,7 +260,7 @@ export function EvaluationDialog({
           maxPoints: maxPointsNum,
           section: subject.hasSplit ? section : undefined,
           isSummative: isSummative,
-          ...(difficulty && { difficulty })
+          difficulty
         })
       }
 
@@ -304,7 +304,7 @@ export function EvaluationDialog({
         section: subject.hasSplit ? section : undefined,
         isSummative: isSummative,
         subEvaluations: finalSubEvaluations,
-        ...(difficulty && { difficulty })
+        difficulty
       })
     }
 

--- a/src/components/EvaluationDialog.tsx
+++ b/src/components/EvaluationDialog.tsx
@@ -560,12 +560,12 @@ export function EvaluationDialog({
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="eval-difficulty">Dificultad (opcional)</Label>
-            <Select value={difficulty || ''} onValueChange={(val) => setDifficulty(val as DifficultyLevel || undefined)}>
+            <Select value={difficulty || 'unspecified'} onValueChange={(val) => setDifficulty(val === 'unspecified' ? undefined : (val as DifficultyLevel))}>
               <SelectTrigger id="eval-difficulty">
                 <SelectValue placeholder="Sin especificar" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Sin especificar</SelectItem>
+                <SelectItem value="unspecified">Sin especificar</SelectItem>
                 <SelectItem value="easy">Fácil</SelectItem>
                 <SelectItem value="normal">Normal</SelectItem>
                 <SelectItem value="hard">Difícil</SelectItem>

--- a/src/components/SubjectDialog.tsx
+++ b/src/components/SubjectDialog.tsx
@@ -47,7 +47,7 @@ export function SubjectDialog({ open, onOpenChange, onSave, subject }: SubjectDi
       hasSplit,
       theoryWeight: theory,
       practiceWeight: practice,
-      ...(difficulty && { difficulty })
+      difficulty
     })
 
     setName('')

--- a/src/components/SubjectDialog.tsx
+++ b/src/components/SubjectDialog.tsx
@@ -90,12 +90,12 @@ export function SubjectDialog({ open, onOpenChange, onSave, subject }: SubjectDi
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="difficulty">Dificultad (opcional)</Label>
-            <Select value={difficulty || ''} onValueChange={(val) => setDifficulty(val as DifficultyLevel || undefined)}>
+            <Select value={difficulty || 'unspecified'} onValueChange={(val) => setDifficulty(val === 'unspecified' ? undefined : (val as DifficultyLevel))}>
               <SelectTrigger id="difficulty">
                 <SelectValue placeholder="Sin especificar" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Sin especificar</SelectItem>
+                <SelectItem value="unspecified">Sin especificar</SelectItem>
                 <SelectItem value="easy">Fácil</SelectItem>
                 <SelectItem value="normal">Normal</SelectItem>
                 <SelectItem value="hard">Difícil</SelectItem>


### PR DESCRIPTION
## Summary

Fixed Radix UI error when rendering the optional difficulty selectors in EvaluationDialog and SubjectDialog components. The components were using empty string values in SelectItem elements, which Radix UI does not allow.

## Changes

- Replaced empty string (`""`) with `"unspecified"` as the value for "Sin especificar" SelectItem options
- Updated `onValueChange` handlers to properly convert the `"unspecified"` value back to `undefined` for the React state
- Applied fix to both EvaluationDialog and SubjectDialog difficulty selects

## Why

Radix UI requires SelectItem to have non-empty values. The error "A <Select.Item /> must have a value prop that is not an empty" was triggered whenever the app tried to render these components.

## Testing

- Build passes without errors
- TypeScript compilation successful
- No functional changes to the UI behavior—the difficulty selects work exactly as before, just without the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)